### PR TITLE
Add preset argument

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -26,6 +26,9 @@ inputs:
     descr: reference to a notebooks volume
   volumes_results_remote:
     descr: reference to a results volume
+  preset:
+    description: Preset to use for the job
+    default: "cpu-small"
 
 job:
   name: $[[ inputs.job_name ]]
@@ -35,6 +38,7 @@ job:
   browse: True
   detach: True
   pass_config: True
+  preset: "$[[ inputs.preset ]]"
   volumes:
     - "$[[ inputs.volumes_data_remote ]]:/project/data:ro"
     - "$[[ inputs.volumes_code_remote ]]:/project/modules:rw"


### PR DESCRIPTION
This pull request includes changes to the `action.yaml` file to add a new input and use it in the job configuration. The most important changes are:

* Added a new input `preset` with a description and a default value of "cpu-small" in the `inputs` section.
* Updated the `job` section to include the new `preset` input.